### PR TITLE
Build the csv module

### DIFF
--- a/mk/python/3.3.5/Setup
+++ b/mk/python/3.3.5/Setup
@@ -194,7 +194,7 @@ select selectmodule.c	# select(2); not on ancient System V
 #mmap mmapmodule.c
 
 # CSV file helper
-#_csv _csv.c
+_csv _csv.c
 
 # Socket module helper for socket(2)
 _socket socketmodule.c


### PR DESCRIPTION
Make sure that the CSV file helper gets compiled so that the python csv module works correctly.